### PR TITLE
Bugfixes for small interleaved discs like those found on period hardware

### DIFF
--- a/software/cpm/cpm_dev/fsck/fsck.i
+++ b/software/cpm/cpm_dev/fsck/fsck.i
@@ -22,7 +22,7 @@ BDIS_CHARS_MAX  equ (VT100_ROWS / 2) * VT100_COLS ; Maximum display area for blo
 BITDEF ALLCF_UNUSED, 7                  ; Set if any allocation is unused
 BITDEF ALLCF_SPARSE, 6                  ; Set file contains a hole
 ; LS bits serve as a counter.
-ALLCF_COUNT     equ 0x0f                ; Used allocation counter
+ALLCF_COUNT     equ 0x1f                ; Used allocation counter
 ;
 ;
 ;

--- a/software/cpm/cpm_dev/fsck/fsck.z80
+++ b/software/cpm/cpm_dev/fsck/fsck.z80
@@ -205,6 +205,7 @@ operands_ok     ld c, BDOS_RESET_DISK_SYS   ; Reset Disk System
 drive_sel_ok
 ;
 ; Find address of DPB.
+                ld (dph), hl            ; Save for later
                 ld de, DPH_DPB          ; Offset to pointer to DPB
                 add hl, de
                 ld e, (hl)              ; Fetch pointer
@@ -1563,6 +1564,14 @@ ss_track_done   ld b, h                 ; Move track number to BC
 ;
 ; Set sector.
                 pop bc                  ; Fetch sector
+                ld hl, (dph)            ; put translate table pointer in DE
+                ld e, (hl)
+                inc hl
+                ld d, (hl)
+                ld hl, BIOS_SECTRAN     ; ask for translation of BC (return in HL)
+                call cbios
+                ld b,h                  ; back into BC for SETSEC
+                ld c,l
                 ld (sector), bc         ; Save sector for status reporting
                 ld hl, BIOS_SETSEC      ; Set sector number
                 call cbios              ; Call BIOS with some registers saved
@@ -1637,6 +1646,7 @@ file_count      defs 2              ; Files count
 unused_count    defs 2              ; Unused entry count
 blocks_used     defs 2              ; Number of blocks used
 phys_extent     defs 2              ; Calculated physical extent
+dph             defs 2              ; Pointer to Disk Parameter Header (DPH_xxx)
 dpb             defs 2              ; Pointer to Disk Parameter Block (DPB_xxx)
 dire            defs 2              ; Pointer to directory entry structure (DIRE_xxx)
 fie             defs 2              ; Pointer to file information structure (FI_xxx)

--- a/software/cpm/cpm_dev/fsck/fsck.z80
+++ b/software/cpm/cpm_dev/fsck/fsck.z80
@@ -522,7 +522,7 @@ slf_ext_done    ld ix, (dpb)
 ; C - flags and counter
                 ld a, (ix + DPB_DSM + 1)    ; Fetch MS byte of DSM
                 and a
-                jr z, slf_bytes         ; Jump if > 255 blocks
+                jr z, slf_bytes         ; Jump if < 256 blocks
 ;
 ; The maximum block number is >= 256, so the allocation list is in words.
                 ld b, 8
@@ -565,7 +565,7 @@ slf_by_alu_used inc c                   ; Keep count
                 call flag_block         ; Mark block used
                 jp c, sl_err_stop       ; Error if already used
                 bit ALLCF_UNUSED_BIT, c
-                jr z, slf_wd_alu_dn     ; Jump if no unused entries encountered
+                jr z, slf_by_alu_dn     ; Jump if no unused entries encountered
 ; This used entry is preceeded by an unused one. This means we have a holed, or
 ; "sparse" file.
                 set ALLCF_SPARSE_BIT, c ; Hole detected


### PR DESCRIPTION
This is at least part of the fix for Issue #2

With this change, the filenames and user numbers are found correctly, but each file reports "block number out of range".

```
[from track 2 sector 1]
U0 MOVCPM  .COM - block number out of range
U0 PIP     .COM - block number out of range
U0 SUBMIT  .COM - block number out of range
U0 XSUB    .COM - block number out of range
[from track 2 sector 7]
U0 ED      .COM - block number out of range
U0 ASM     .COM - block number out of range
U0 DDT-ORIG.COM - block number out of range
U0 LOAD    .COM - block number out of range
[etc]
```