### PR TITLE
proposal for nicer com build with ld80

### DIFF
--- a/software/cpm/cpm_dev/fsck/makefile
+++ b/software/cpm/cpm_dev/fsck/makefile
@@ -38,11 +38,10 @@ $(TARGET).COM: $(OBJS) $(SOBJS)
 # location in use.
 	@btime btime cseg 0x24	# Generate btime.rel with current date and time
 	@rm btime.z80		# Remove file to prevent confusion with %.z80 rule
-	ld80 -O bin -o $(TARGET_LC).tmp -s $(TARGET_LC).sym -m -P 0100 -c $(OBJS) btime.rel $(SOBJS)
-# Remove initial bytes (I can't find neater way of doing this).
-	dd bs=4096 skip=256 iflag=skip_bytes < $(TARGET_LC).tmp > $(TARGET).COM
+	ld80 -O hex -o $(TARGET_LC).hex -s $(TARGET_LC).sym -m -P 0100 -c $(OBJS) btime.rel $(SOBJS)
+	objcopy -Iihex -Obinary $(TARGET_LC).hex $(TARGET).COM
 	@rm btime.rel		# Remove to prevent unnecessary re-linking
-	@rm $(TARGET_LC).tmp
+	@rm $(TARGET_LC).hex
 	# File size in bytes:
 	stat -c "%s" $@
 


### PR DESCRIPTION
Instead of truncating the 256-byte block with zeros using `dd`, create a HEX file and convert it to a binary file (COM) using

    objcopy -Iihex -Obinary $(TARGET_LC).hex $(TARGET).COM

Or use one of the modified ld80 versions by [durgadas311](https://github.com/durgadas311/ld80.git) or [myself](https://github.com/Ho-Ro/ld80.git)